### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Options are optional.
 
 - encoding: default to `utf8`
 - delimiter: default to `,`
-- newlint: default to `\n`
+- newline: default to `\n`
 - quote: default to `\"`
 
 ## Definitions


### PR DESCRIPTION
Change `newlint` to `newline` in options section.